### PR TITLE
Add erlang-solutions centos repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ WORKDIR /usr/local/src
 
 RUN yum install -y gcc gcc-c++ make openssl-devel ncurses-devel && yum clean all
 RUN yum install -y epel-release && yum clean all
-RUN yum install -y http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_3_general/esl-erlang_18.0-1~centos~7_amd64.rpm && yum clean all
-RUN yum install -y sudo wget git tar bzip2 incron vim nodejs npm && yum clean all
+RUN wget http://packages.erlang-solutions.com/erlang-solutions-1.0-1.noarch.rpm
+RUN rpm -Uvh erlang-solutions-1.0-1.noarch.rpm
+RUN yum install -y sudo wget git tar bzip2 incron vim nodejs npm erlang && yum clean all
 ########## MIDDLEWARE ##########
 
 


### PR DESCRIPTION
This way we don't have to use hard-coded urls to grab the release from.

We download and install the erlang-solutions repo and then install from that. We can specify versions by using yum version specifications
